### PR TITLE
Week 3: Add many-to-many relationship between lessons and topics

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,3 +1,7 @@
 class Lesson < ApplicationRecord
   belongs_to :course
+
+  # Many-to-many relationship with topics
+  has_many :lessons_topics
+  has_many :topics, through: :lessons_topics
 end

--- a/app/models/lessons_topic.rb
+++ b/app/models/lessons_topic.rb
@@ -1,0 +1,7 @@
+class LessonsTopic < ApplicationRecord
+  # This join model creates the many-to-many relationship between lessons and topics
+  # Each record represents one topic being covered by one lesson
+
+  belongs_to :lesson
+  belongs_to :topic
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,8 @@
+class Topic < ApplicationRecord
+  # This model represents educational topics that can be associated with lessons
+  # Each topic has a unique title like "SQL", "Data Modeling", etc.
+
+  # Many-to-many relationship with lessons
+  has_many :lessons_topics
+  has_many :lessons, through: :lessons_topics
+end

--- a/db/migrate/20250724043055_create_topics.rb
+++ b/db/migrate/20250724043055_create_topics.rb
@@ -1,0 +1,9 @@
+class CreateTopics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :topics do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250724054221_create_lessons_topics.rb
+++ b/db/migrate/20250724054221_create_lessons_topics.rb
@@ -1,0 +1,9 @@
+class CreateLessonsTopics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lessons_topics, id: false do |t|
+      t.references :lesson, null: false, foreign_key: true
+      t.references :topic, null: false, foreign_key: true
+    end
+    add_index :lessons_topics, [:lesson_id, :topic_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_054221) do
   create_table "coding_classes", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -49,6 +49,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
     t.index ["course_id"], name: "index_lessons_on_course_id"
   end
 
+  create_table "lessons_topics", id: false, force: :cascade do |t|
+    t.integer "lesson_id", null: false
+    t.integer "topic_id", null: false
+    t.index ["lesson_id", "topic_id"], name: "index_lessons_topics_on_lesson_id_and_topic_id", unique: true
+    t.index ["lesson_id"], name: "index_lessons_topics_on_lesson_id"
+    t.index ["topic_id"], name: "index_lessons_topics_on_topic_id"
+  end
+
   create_table "mentor_enrollment_assignments", force: :cascade do |t|
     t.integer "mentor_id", null: false
     t.integer "enrollment_id", null: false
@@ -75,6 +83,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "topics", force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "trimesters", force: :cascade do |t|
     t.string "year"
     t.string "term"
@@ -90,6 +104,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
   add_foreign_key "enrollments", "courses"
   add_foreign_key "enrollments", "students"
   add_foreign_key "lessons", "courses"
+  add_foreign_key "lessons_topics", "lessons"
+  add_foreign_key "lessons_topics", "topics"
   add_foreign_key "mentor_enrollment_assignments", "enrollments"
   add_foreign_key "mentor_enrollment_assignments", "mentors"
 end

--- a/lesson-03-assignment
+++ b/lesson-03-assignment
@@ -1,0 +1,75 @@
+# Lesson 3 Assignment: Many-to-Many Relationship Implementation
+
+## 1. What tables do you need to add? Decide on table names and their associations to each other and any existing tables/models.
+
+We need to add two tables:
+- `topics` - Stores the educational topics (SQL, CSS, JavaScript, etc.)
+- `lessons_topics` - Join table that creates the many-to-many relationship between lessons and topics
+
+The associations work as follows:
+- A lesson has many topics through lessons_topics
+- A topic has many lessons through lessons_topics
+- The lessons_topics table belongs to both lesson and topic
+
+## 2. What columns are necessary for the associations you decided on?
+
+For the `topics` table:
+- `id` (primary key, automatically created by Rails)
+
+For the `lessons_topics` join table:
+- `lesson_id` (foreign key referencing lessons.id)
+- `topic_id` (foreign key referencing topics.id)
+- No `id` column needed (we use `id: false` in the migration)
+
+## 3. What other columns (if any) need to be included on the tables? What other data needs to be stored?
+
+For the `topics` table:
+- `title` (string, not null) - Stores the topic name like "SQL", "JavaScript", etc.
+- `created_at` and `updated_at` (timestamps) - Automatically added by Rails
+
+For the `lessons_topics` join table:
+- No additional columns needed for the basic many-to-many relationship
+- We chose not to include timestamps as they're not necessary for a simple join table
+
+## 4. Write out each table's name and column names with data types.
+
+**topics table:**
+- id: integer (primary key, auto-increment)
+- title: string (varchar 255), not null
+- created_at: datetime, not null
+- updated_at: datetime, not null
+
+**lessons_topics table:**
+- lesson_id: integer, not null, foreign key
+- topic_id: integer, not null, foreign key
+- Composite unique index on (lesson_id, topic_id) to prevent duplicates
+- Individual indexes on both foreign keys for query performance
+
+## 5. Generator commands used:
+
+First migration (topics table):
+bin/rails generate migration CreateTopics
+
+Second migration (join table):
+bin/rails generate migration CreateLessonsTopics
+
+## Implementation Notes:
+
+1. We used `t.references` in the join table migration, which automatically creates indexes on the foreign keys.
+
+2. We added a composite unique index to prevent the same topic from being associated with the same lesson multiple times.
+
+3. The join table uses `id: false` because the combination of lesson_id and topic_id serves as a natural composite key.
+
+4. We created a LessonsTopic model (following Rails naming conventions) to represent the join relationship, even though Rails can work without it. This gives us flexibility to add validations or methods later.
+
+5. We updated both the Lesson and Topic models with the appropriate has_many associations to complete the bidirectional many-to-many relationship.
+
+## Testing Results:
+
+Successfully created associations between lessons and topics in the Rails console, demonstrating:
+- Adding single topics to lessons
+- Adding multiple topics at once
+- Querying lessons by topic
+- Querying topics by lesson
+- Counting associations


### PR DESCRIPTION
## Summary
This PR implements the Week 3 assignment by adding a many-to-many relationship between lessons and topics.

## Changes
1. **Added Topics model** - Allows categorizing lessons by topic
2. **Created lessons_topics join table** - Implements many-to-many relationship
3. **Updated Lesson model** - Added has_and_belongs_to_many :topics association
4. **Added migrations** - For topics table and lessons_topics join table
5. **Updated schema.rb** - Reflects new database structure
6. **Added lesson-03-assignment documentation** - Complete assignment answers

## Database Changes
- New `topics` table with title field
- New `lessons_topics` join table with composite unique index
- Foreign key constraints properly set up

Note: This PR is to my personal fork only.