### PR TITLE
Add test_output.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 log
 storage
 .idea/
+test_output.txt


### PR DESCRIPTION
This PR adds
  test_output.txt to .gitignore. This change was cherry-picked from PR #1 as it was the only unique and useful commit not already in
  main.